### PR TITLE
tests: Fix aiohttp fixtures in test cases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[tool:pytest]
+asyncio_mode = auto
+minversion = 6.0
+addopts = -ra -q
+testpaths =
+    tests

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,7 @@ import json
 
 from aiohttp import WSMsgType, web
 from aiohttp.web_exceptions import HTTPClientError
-from pytest_aiohttp import aiohttp_server
+from pytest_aiohttp.plugin import aiohttp_server
 
 from tests.data import TEST_METHOD_RESPONSES
 


### PR DESCRIPTION
Updates to pytest-aiohttp moved some of the fixtures, also added asyncio=auto to test configuration to squash warning about legacy mode.