### PR TITLE
ci: Add version to release commit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,12 +12,12 @@ ci: true
 dryRun: false
 debug: false
 plugins:
-  - - '@semantic-release/commit-analyzer'
+  - - "@semantic-release/commit-analyzer"
     - preset: angular
-  - '@semantic-release/release-notes-generator'
-  - - '@semantic-release/changelog'
+  - "@semantic-release/release-notes-generator"
+  - "semantic-release-pypi"
+  - "@semantic-release/github"
+  - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
-  - - '@semantic-release/git'
-    - assets: ['CHANGELOG.md']
-  - 'semantic-release-pypi'
-  - '@semantic-release/github'
+  - - "@semantic-release/git"
+    - assets: ["CHANGELOG.md", "setup.py", "setup.cfg"]


### PR DESCRIPTION
Updates the **setup.cfg** file to contain the latest version from **semantic-release** so that packages may also have correct information when built locally.