### PR TITLE
Fix aiohttp deprecation message

### DIFF
--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -306,7 +306,7 @@ class WebsocketClient:
 
             except ClientResponseError as error:
                 _LOGGER.warning("Websocket request error: %s", error)
-                if error.code == 401:
+                if error.status == 401:
                     _LOGGER.error("API access is unauthorized")
                     self.state = WEBSOCKET_STATE_STOPPING
                     await set_exception(ClientNotAuthenticatedError)


### PR DESCRIPTION
ClientResponseError's code property has been deprecated since version 3.1 and is replaced by the equivalent status property. [Link to the aiohttp documentation](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponseError).

This is a drive-by fix. I happened to notice this in logs when moonraker-api is being built in [nixpkgs](https://github.com/NixOS/nixpkgs).