### PR TITLE
Moonraker route_prefix support

### DIFF
--- a/moonraker.py
+++ b/moonraker.py
@@ -29,7 +29,7 @@ async def main(args):
         return
 
     listener = WSHandler()
-    client = MoonrakerClient(host=args.host, listener=listener, api_key=args.api_key)
+    client = MoonrakerClient(host=args.host, listener=listener, port=args.port, route_prefix=args.route_prefix, ssl=args.ssl, api_key=args.api_key)
     await client.connect()
 
     if args.reset:
@@ -42,6 +42,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Moonraker API command line client.")
     parser.add_argument("--discovery", default=False, action="store_true")
     parser.add_argument("--host", default="atlas.local", metavar="h")
+    parser.add_argument("--port", default=7125)
+    parser.add_argument("--ssl", default=False, action="store_true")
+    parser.add_argument("--route-prefix", default=None)
     parser.add_argument(
         "--api-key", default="e438d2303790417ba4e564520df30893", action="store"
     )

--- a/moonraker_api/moonrakerclient.py
+++ b/moonraker_api/moonrakerclient.py
@@ -42,6 +42,7 @@ class MoonrakerClient(WebsocketClient):
         listener: MoonrakerListener,
         host: str,
         port: int = 7125,
+        route_prefix: str | None = None,
         api_key: str | None = None,
         ssl: bool = False,
         loop: AbstractEventLoop = None,
@@ -54,13 +55,15 @@ class MoonrakerClient(WebsocketClient):
             listener (MoonrakerListen): Event listener
             host (str): hostname or IP address of the printer
             port (int, optional): Defaults to 7125
+            route_prefix (str, optional):
+                Defaults to none, configure if set on moonraker
             api_key (str, optional): API key
             loop (AbstractEventLoop, option):
                 Provide an optional asyncio loop for tasks
             timeout (int, option): Timeout in seconds for websockets
         """
         WebsocketClient.__init__(
-            self, listener, host, port, api_key, ssl, loop, timeout, session
+            self, listener, host, port, route_prefix, api_key, ssl, loop, timeout, session
         )
 
     async def _loop_recv_internal(self, message: Any) -> None:

--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -76,7 +76,7 @@ class ClientNotAuthenticatedError(Exception):
 
 
 class WebsocketClient:
-    """Moonraker API client class, repesents an API instance
+    """Moonraker API client class, represents an API instance
 
     Attributes:
       host: hostname or IP address of the printer

--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -88,6 +88,7 @@ class WebsocketClient:
         listener: WebsocketStatusListener,
         host: str,
         port: int = 7125,
+        route_prefix: str | None = None,
         api_key: str | None = None,
         ssl: bool = False,
         loop: AbstractEventLoop = None,
@@ -100,6 +101,8 @@ class WebsocketClient:
             listener (MoonrakerListen): Event listener
             host (str): hostname or IP address of the printer
             port (int, optional): Defaults to 7125
+            route_prefix (str, optional):
+                Defaults to none, configure if set on moonraker
             api_key (str, options): API key
             loop (AbstractEventLoop, option):
                 Provide an optional asyncio loop for tasks
@@ -107,6 +110,7 @@ class WebsocketClient:
         self.listener = listener or WebsocketStatusListener()
         self.host = host
         self.port = port
+        self.route_prefix = route_prefix
         self.api_key = api_key
         self.ssl = ssl
         self._timeout = timeout
@@ -162,6 +166,8 @@ class WebsocketClient:
 
     def _build_websocket_uri(self) -> str:
         protocol = "wss://" if self.ssl else "ws://"
+        if self.route_prefix:
+            return f"{protocol}{self.host}:{self.port}/{self.route_prefix}/websocket"
         return f"{protocol}{self.host}:{self.port}/websocket"
 
     def _get_next_tx_id(self) -> int:


### PR DESCRIPTION
As seen in the docs it is possible to configure Moonraker on a subpath:
```ini
route_prefix:
#   A prefix prepended to the path for each HTTP endpoint.  For example
#   if the route_prefix is set to moonraker/printer1, then the server info
#   endpoint is available at:
#     http://myprinter.local/moonraker/printer1/server/info
#
#   This is primarily useful for installations that feature multiple instances
#   of Moonraker, as it allows a reverse proxy identify the correct instance based
#   on the path and redirect requests without a rewrite.  Note that frontends must feature
#   support for HTTP endpoints with a route prefix to communicate with Moonraker when
#   this option is set. The default is no route prefix.
```
https://moonraker.readthedocs.io/en/latest/configuration/

Tested locally with the `moonraker.py` (also committed the extra arguments I needed to test) see below:

```console
# python ./moonraker.py --host example.com --port 443 --route-prefix moonraker --ssl
moonraker_api.websockets.websocketclient - DEBUG - Websocket changing to state ws_connecting
__main__ - DEBUG - Handling state_changed event to ws_connecting
moonraker_api.websockets.websocketclient - DEBUG - Websocket changing to state ws_connected
__main__ - DEBUG - Handling state_changed event to ws_connected
moonraker_api.websockets.websocketclient - DEBUG - Sending message {"jsonrpc": "2.0", "method": "printer.info", "id": 127157}
moonraker_api.websockets.websocketclient - DEBUG - Received message: WSMessage(type=<WSMsgType.TEXT: 1>, data='{"jsonrpc":"2.0","result":{"state":"shutdown","state_message":"Lost communication with MCU \'mcu\'\\nOnce the underlying issue is corrected, use the\\n\\"FIRMWARE_RESTART\\" command to reset the firmware, reload the\\nconfig, and restart the host software.\\nPrinter is shutdown\\n","hostname":"ender3","klipper_path":"/home/klipper/klipper","python_path":"/home/klipper/klippy-env/bin/python","process_id":65020,"user_id":1000,"group_id":1000,"log_file":"/home/klipper/printer_data/logs/klippy.log","config_file":"/home/klipper/printer_data/config/printer.cfg","software_version":"v0.13.0-375-gba79d72f","cpu_info":"4 core ?"},"id":127157}', extra='')
```