### PR TITLE
ci: update Python test matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Update the GitHub Actions Python test matrix to match currently supported released Python versions.
- Drop EOL Python 3.8 and 3.9 from CI.
- Add Python 3.13 and 3.14 to CI coverage.

## Validation

- Ran `git diff --check HEAD~1..HEAD`.

## Notes

Auto-merge should merge this PR once CI and required checks pass.