### PR TITLE
Drop support for end-of-life Python versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-# Update the VARIANT arg in devcontainer.json to pick a Python version: 3, 3.8, 3.7, 3.6 
+# Update the VARIANT arg in devcontainer.json to pick a supported Python version.
 # To fully customize the contents of this image, use the following Dockerfile instead:
 # https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/python-3/.devcontainer/base.Dockerfile
 ARG VARIANT="3"
@@ -20,4 +20,3 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \
 #    && apt-get -y install --no-install-recommends <your-package-list-here>
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		// Update 'VARIANT' to pick a Python version. Rebuild the container 
-		// if it already exists to update. Available variants: 3, 3.6, 3.7, 3.8 
+		// Update 'VARIANT' to pick a supported Python version. Rebuild the container
+		// if it already exists to update.
 		"args": { "VARIANT": "3" }
 	},
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,15 +47,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
-          pip install importlib_metadata==7.2.1
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - uses: actions/setup-node@v4
         with:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="moonraker-api",
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=requirements,
     author="Clifford Roche",
     author_email="",
@@ -19,6 +19,11 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
## Summary
- require Python 3.10 or newer in package metadata
- keep CI testing on Python 3.10 through 3.14
- update the publish job to use Python 3.10 and remove the obsolete `importlib_metadata` backport install
- stop advertising obsolete devcontainer Python variants

## Release impact
This commit uses `feat!` with a `BREAKING CHANGE` footer so semantic-release should publish a major version after the PR lands on `main`.

## Validation
- `git diff --check`
- `pytest --cov-report=xml --cov=moonraker_api tests/` in a temporary Python 3.14.5 virtualenv: 13 passed, 3 skipped