### PR TITLE
Constrain PyPI build metadata for publishing

### DIFF
--- a/.github/pypi-build-constraints.txt
+++ b/.github/pypi-build-constraints.txt
@@ -1,0 +1,1 @@
+setuptools<77

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PIP_CONSTRAINT: .github/pypi-build-constraints.txt
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           PYPI_USER: ${{ secrets.PYPI_USER }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- add a PyPI build constraints file pinning the isolated build backend below the metadata 2.4 behavior
- export `PIP_CONSTRAINT` for the semantic-release publish step

## Why
The `v3.0.0` semantic-release run correctly selected a major release and built artifacts, but PyPI upload rejected the generated distributions because they used `Metadata-Version: 2.4` while the upload path reported support through 2.3.

## Validation
- reproduced the local package build with unconstrained metadata `2.4`
- rebuilt with `PIP_CONSTRAINT=.github/pypi-build-constraints.txt`, producing metadata `2.2` for both sdist and wheel
- `twine check dist/*` passed
- `git diff --check`