### PR TITLE
feat!: Add support for route_prefix

### DIFF
--- a/moonraker.py
+++ b/moonraker.py
@@ -29,7 +29,7 @@ async def main(args):
         return
 
     listener = WSHandler()
-    client = MoonrakerClient(host=args.host, listener=listener, api_key=args.api_key)
+    client = MoonrakerClient(host=args.host, listener=listener, port=args.port, route_prefix=args.route_prefix, ssl=args.ssl, api_key=args.api_key)
     await client.connect()
 
     if args.reset:
@@ -42,6 +42,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Moonraker API command line client.")
     parser.add_argument("--discovery", default=False, action="store_true")
     parser.add_argument("--host", default="atlas.local", metavar="h")
+    parser.add_argument("--port", default=7125)
+    parser.add_argument("--ssl", default=False, action="store_true")
+    parser.add_argument("--route-prefix", default=None)
     parser.add_argument(
         "--api-key", default="e438d2303790417ba4e564520df30893", action="store"
     )

--- a/moonraker_api/moonrakerclient.py
+++ b/moonraker_api/moonrakerclient.py
@@ -42,6 +42,7 @@ class MoonrakerClient(WebsocketClient):
         listener: MoonrakerListener,
         host: str,
         port: int = 7125,
+        route_prefix: str | None = None,
         api_key: str | None = None,
         ssl: bool = False,
         loop: AbstractEventLoop = None,
@@ -54,13 +55,15 @@ class MoonrakerClient(WebsocketClient):
             listener (MoonrakerListen): Event listener
             host (str): hostname or IP address of the printer
             port (int, optional): Defaults to 7125
+            route_prefix (str, optional):
+                Defaults to none, configure if set on moonraker
             api_key (str, optional): API key
             loop (AbstractEventLoop, option):
                 Provide an optional asyncio loop for tasks
             timeout (int, option): Timeout in seconds for websockets
         """
         WebsocketClient.__init__(
-            self, listener, host, port, api_key, ssl, loop, timeout, session
+            self, listener, host, port, route_prefix, api_key, ssl, loop, timeout, session
         )
 
     async def _loop_recv_internal(self, message: Any) -> None:

--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -76,7 +76,7 @@ class ClientNotAuthenticatedError(Exception):
 
 
 class WebsocketClient:
-    """Moonraker API client class, repesents an API instance
+    """Moonraker API client class, represents an API instance
 
     Attributes:
       host: hostname or IP address of the printer

--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -166,8 +166,9 @@ class WebsocketClient:
 
     def _build_websocket_uri(self) -> str:
         protocol = "wss://" if self.ssl else "ws://"
-        if self.route_prefix:
-            return f"{protocol}{self.host}:{self.port}/{self.route_prefix}/websocket"
+        route_prefix = self.route_prefix.strip("/") if self.route_prefix else None
+        if route_prefix:
+            return f"{protocol}{self.host}:{self.port}/{route_prefix}/websocket"
         return f"{protocol}{self.host}:{self.port}/websocket"
 
     def _get_next_tx_id(self) -> int:

--- a/moonraker_api/websockets/websocketclient.py
+++ b/moonraker_api/websockets/websocketclient.py
@@ -88,6 +88,7 @@ class WebsocketClient:
         listener: WebsocketStatusListener,
         host: str,
         port: int = 7125,
+        route_prefix: str | None = None,
         api_key: str | None = None,
         ssl: bool = False,
         loop: AbstractEventLoop = None,
@@ -100,6 +101,8 @@ class WebsocketClient:
             listener (MoonrakerListen): Event listener
             host (str): hostname or IP address of the printer
             port (int, optional): Defaults to 7125
+            route_prefix (str, optional):
+                Defaults to none, configure if set on moonraker
             api_key (str, options): API key
             loop (AbstractEventLoop, option):
                 Provide an optional asyncio loop for tasks
@@ -107,6 +110,7 @@ class WebsocketClient:
         self.listener = listener or WebsocketStatusListener()
         self.host = host
         self.port = port
+        self.route_prefix = route_prefix
         self.api_key = api_key
         self.ssl = ssl
         self._timeout = timeout
@@ -162,6 +166,8 @@ class WebsocketClient:
 
     def _build_websocket_uri(self) -> str:
         protocol = "wss://" if self.ssl else "ws://"
+        if self.route_prefix:
+            return f"{protocol}{self.host}:{self.port}/{self.route_prefix}/websocket"
         return f"{protocol}{self.host}:{self.port}/websocket"
 
     def _get_next_tx_id(self) -> int:

--- a/tests/test_moonrakerclient.py
+++ b/tests/test_moonrakerclient.py
@@ -7,7 +7,7 @@
 """Moonraker client API tests."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from aiohttp import web
@@ -18,6 +18,7 @@ from moonraker_api.const import (
     WEBSOCKET_STATE_STOPPED,
     WEBSOCKET_STATE_STOPPING,
 )
+from moonraker_api.moonrakerclient import MoonrakerClient, MoonrakerListener
 from moonraker_api.websockets.websocketclient import (
     ClientAlreadyConnectedError,
     ClientNotAuthenticatedError,
@@ -34,6 +35,40 @@ from .data import (
     TEST_DATA_SIMPLE_RESPONSE,
     TEST_DATA_SUPPORTED_MODULES,
 )
+
+
+@pytest.mark.parametrize(
+    ("route_prefix", "expected_uri"),
+    [
+        (None, "ws://127.0.0.1:7125/websocket"),
+        ("", "ws://127.0.0.1:7125/websocket"),
+        ("/", "ws://127.0.0.1:7125/websocket"),
+        ("moonraker", "ws://127.0.0.1:7125/moonraker/websocket"),
+        ("/moonraker", "ws://127.0.0.1:7125/moonraker/websocket"),
+        ("moonraker/", "ws://127.0.0.1:7125/moonraker/websocket"),
+        ("/moonraker/", "ws://127.0.0.1:7125/moonraker/websocket"),
+        (
+            "moonraker/printer1",
+            "ws://127.0.0.1:7125/moonraker/printer1/websocket",
+        ),
+        (
+            "/moonraker/printer1/",
+            "ws://127.0.0.1:7125/moonraker/printer1/websocket",
+        ),
+    ],
+)
+async def test_build_websocket_uri_normalizes_route_prefix(route_prefix, expected_uri):
+    """Test websocket URI route prefix creation and slash normalization."""
+    listener = Mock(name="MoonrakeListener", spec=MoonrakerListener)
+    moonraker = MoonrakerClient(
+        host="127.0.0.1",
+        port=7125,
+        listener=listener,
+        route_prefix=route_prefix,
+        loop=asyncio.get_running_loop(),
+    )
+
+    assert moonraker._build_websocket_uri() == expected_uri
 
 
 async def test_connect(aiohttp_server, moonraker):


### PR DESCRIPTION
## Summary

Follow-up to #10.

- Normalize leading and trailing slashes from `route_prefix` before building the websocket URI.
- Add tests covering route prefix URI creation and slash normalization, including empty, slash-only, single-segment, and nested prefixes.

## Validation

- `git diff --check`
- `python -m pytest` in a temporary Python 3.13 environment: `22 passed, 3 skipped`

Note: the test run still reports existing aiohttp/test-server deprecation warnings unrelated to this change.